### PR TITLE
Removes adding of app/channels to autoload paths

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,8 +11,5 @@ module ActioncableExamples
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
-    config.autoload_paths += %W(
-      #{config.root}/app/channels
-    )
   end
 end


### PR DESCRIPTION
All directories under app are included in the autoload_path by default, so it is not necessary to add the directory.