### PR TITLE
Example with Docker Compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 /tmp/*
 !/log/.keep
 !/tmp/.keep
+
+/vendor/bundle
+/.bash_history

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,6 +19,9 @@ Rails.application.configure do
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 
+  # Log to STDOUT if the environment variable is present (i.e. Docker Compose example)
+  config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT)) if ENV['RAILS_LOG_TO_STDOUT']
+
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 

--- a/config/redis/cable.yml
+++ b/config/redis/cable.yml
@@ -5,9 +5,7 @@
 #   :timeout: 1
 
 local: &local
-  :url: redis://localhost:6379
-  :host: localhost
-  :port: 6379
+  :url: <%= ENV.fetch 'REDIS_URL', 'redis://localhost:6379' %> # Fetch environment variable (i.e. Docker Compose example)
   :timeout: 1
   :inline: true
 development: *local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+---
+# The Redis Container:
+redis:
+  image: redis:3.0
+  ports:
+    - "6379:6379" # Bind host port 6379 to Redis container's port 6379
+
+# The Web container:
+web: &app_base
+  image: vovimayhem/app-dev:mri-2.2
+  command: rails server -p 3000 -b 0.0.0.0
+  ports:
+    - "3000:3000" # Bind host port 3000 to app container's HTTP port 3000
+  volumes:
+    - .:/app
+  ##############################################################################
+  # With linked containers, Docker writes entries to the container's /etc/hosts.
+  # We'll try here naming the entries docker will insert into the
+  # container's /etc/hosts, so we can use more familiar URL's for our app - See
+  # this container's environment section below:
+  links: &app_links
+    - redis:redis.example.com
+  environment: &app_environment
+
+    # The Redis URL:
+    REDIS_URL: redis://redis.example.com:6379
+
+    RAILS_LOG_TO_STDOUT: true
+
+    # Run the app in the 'development' environment:
+    RACK_ENV: development
+    RAILS_ENV: development
+
+cable:
+  <<: *app_base
+  command: cable
+  ports:
+    - "28080:28080" # Bind host port 28080 to app container's WebSocket port 28080


### PR DESCRIPTION
I added a docker compose example file to quickly launch the example with [Docker Compose](https://docs.docker.com/compose/).

Example usage: 
```bash
# Move to the directory:
cd actioncable-examples

# FIRST TIME ONLY: Run the setup script inside a temporary app container:
docker-compose run --no-deps --rm web setup

# Launch the redis, web & cable containers - will download & launch a working redis container automatically:
docker-compose up
```

Merge to master in case you guys are interested on it :) Cheers!