### PR TITLE
Update for Rails 5 (#16)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 gem 'rails', github: "rails/rails"
 gem 'sprockets-rails', github: "rails/sprockets-rails"
 gem 'arel', github: "rails/arel"
-gem 'actioncable', github: "rails/actioncable"
 
 gem 'sqlite3'
 gem 'puma'
@@ -12,7 +11,7 @@ gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 gem 'coffee-rails', github: "rails/coffee-rails"
 gem 'jquery-rails'
-gem 'turbolinks'
+gem 'turbolinks', github: "rails/turbolinks"
 
 gem 'jbuilder', '~> 2.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,195 +1,186 @@
 GIT
-  remote: git://github.com/rails/actioncable.git
-  revision: 6ee8bb9310f78de85e6b89c8cac33493b0582383
-  specs:
-    actioncable (0.1.0)
-      actionpack (>= 4.2.0)
-      activesupport (>= 4.2.0)
-      celluloid (~> 0.16.0)
-      coffee-rails
-      em-hiredis (~> 0.3.0)
-      faye-websocket (~> 0.9.2)
-      redis (~> 3.0)
-      websocket-driver (= 0.5.4)
-
-GIT
   remote: git://github.com/rails/arel.git
-  revision: 14df08d80fc363fb9932d9534503b3276d30d9a5
+  revision: 63ea665c8083f8069a0d05d4f15cf19e08e470a6
   specs:
-    arel (7.0.0.alpha)
+    arel (7.0.0)
 
 GIT
   remote: git://github.com/rails/coffee-rails.git
-  revision: c05fb725613d96ce969c30a11e7b613e90f9e5e8
+  revision: 29604a59a5d7ea314f54bb52302d68ef134806bf
   specs:
-    coffee-rails (4.1.0)
+    coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
-      railties (>= 4.0.0, < 5.0)
+      railties (>= 4.0.0, < 5.1.x)
 
 GIT
   remote: git://github.com/rails/rails.git
-  revision: c35c0c4a42b26978304613ddffd19c647e2bf5d1
+  revision: 5d1b7c3b441654e8008dcd303f5367883ec660a6
   specs:
-    actionmailer (5.0.0.alpha)
-      actionpack (= 5.0.0.alpha)
-      actionview (= 5.0.0.alpha)
-      activejob (= 5.0.0.alpha)
+    actioncable (5.0.0.beta1)
+      actionpack (= 5.0.0.beta1)
+      coffee-rails (~> 4.1.0)
+      em-hiredis (~> 0.3.0)
+      faye-websocket (~> 0.10.0)
+      redis (~> 3.0)
+      websocket-driver (~> 0.6.1)
+    actionmailer (5.0.0.beta1)
+      actionpack (= 5.0.0.beta1)
+      actionview (= 5.0.0.beta1)
+      activejob (= 5.0.0.beta1)
       mail (~> 2.5, >= 2.5.4)
       rails-dom-testing (~> 1.0, >= 1.0.5)
-    actionpack (5.0.0.alpha)
-      actionview (= 5.0.0.alpha)
-      activesupport (= 5.0.0.alpha)
-      rack (~> 1.6)
+    actionpack (5.0.0.beta1)
+      actionview (= 5.0.0.beta1)
+      activesupport (= 5.0.0.beta1)
+      rack (~> 2.x)
       rack-test (~> 0.6.3)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionview (5.0.0.alpha)
-      activesupport (= 5.0.0.alpha)
+    actionview (5.0.0.beta1)
+      activesupport (= 5.0.0.beta1)
       builder (~> 3.1)
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    activejob (5.0.0.alpha)
-      activesupport (= 5.0.0.alpha)
-      globalid (>= 0.3.0)
-    activemodel (5.0.0.alpha)
-      activesupport (= 5.0.0.alpha)
-      builder (~> 3.1)
-    activerecord (5.0.0.alpha)
-      activemodel (= 5.0.0.alpha)
-      activesupport (= 5.0.0.alpha)
-      arel (= 7.0.0.alpha)
-    activesupport (5.0.0.alpha)
+    activejob (5.0.0.beta1)
+      activesupport (= 5.0.0.beta1)
+      globalid (>= 0.3.6)
+    activemodel (5.0.0.beta1)
+      activesupport (= 5.0.0.beta1)
+    activerecord (5.0.0.beta1)
+      activemodel (= 5.0.0.beta1)
+      activesupport (= 5.0.0.beta1)
+      arel (~> 7.0)
+    activesupport (5.0.0.beta1)
+      concurrent-ruby (~> 1.0)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
+      method_source
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    rails (5.0.0.alpha)
-      actionmailer (= 5.0.0.alpha)
-      actionpack (= 5.0.0.alpha)
-      actionview (= 5.0.0.alpha)
-      activejob (= 5.0.0.alpha)
-      activemodel (= 5.0.0.alpha)
-      activerecord (= 5.0.0.alpha)
-      activesupport (= 5.0.0.alpha)
+    rails (5.0.0.beta1)
+      actioncable (= 5.0.0.beta1)
+      actionmailer (= 5.0.0.beta1)
+      actionpack (= 5.0.0.beta1)
+      actionview (= 5.0.0.beta1)
+      activejob (= 5.0.0.beta1)
+      activemodel (= 5.0.0.beta1)
+      activerecord (= 5.0.0.beta1)
+      activesupport (= 5.0.0.beta1)
       bundler (>= 1.3.0, < 2.0)
-      railties (= 5.0.0.alpha)
-      sprockets-rails
-    railties (5.0.0.alpha)
-      actionpack (= 5.0.0.alpha)
-      activesupport (= 5.0.0.alpha)
+      railties (= 5.0.0.beta1)
+      sprockets-rails (>= 2.0.0)
+    railties (5.0.0.beta1)
+      actionpack (= 5.0.0.beta1)
+      activesupport (= 5.0.0.beta1)
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
 
 GIT
   remote: git://github.com/rails/sprockets-rails.git
-  revision: 34ae184693db41b4e3338940073af9d728881a9c
+  revision: 9ef1ac55b5c22a77bec2552f175bd02f574084a0
   specs:
-    sprockets-rails (3.0.0.beta1)
+    sprockets-rails (3.0.0)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
-      sprockets (>= 3.0.0, < 4.0)
+      sprockets (>= 3.0.0)
+
+GIT
+  remote: git://github.com/rails/turbolinks.git
+  revision: dd31f4b2996f2300631f89339ada82c65b95f4c2
+  specs:
+    turbolinks (3.0.0)
+      coffee-rails
 
 GIT
   remote: git://github.com/rails/web-console.git
-  revision: baafb8e6d074c7b0532b6da6bfd6fe3be5e1549f
+  revision: 6aa9dd67b8f8dc1111ba6b34bb575b0355ee259b
   specs:
-    web-console (2.2.1)
-      activemodel (>= 4.0)
-      binding_of_caller (>= 0.7.2)
-      railties (>= 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
+    web-console (3.0.0)
+      activemodel (>= 4.2)
+      debug_inspector
+      railties (>= 4.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    binding_of_caller (0.7.2)
-      debug_inspector (>= 0.0.1)
     builder (3.2.2)
-    byebug (5.0.0)
-      columnize (= 0.9.0)
-    celluloid (0.16.0)
-      timers (~> 4.0.0)
+    byebug (8.2.1)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
-    coffee-script-source (1.9.1.1)
-    columnize (0.9.0)
+    coffee-script-source (1.10.0)
+    concurrent-ruby (1.0.0)
     debug_inspector (0.0.2)
     em-hiredis (0.3.0)
       eventmachine (~> 1.0)
       hiredis (~> 0.5.0)
     erubis (2.7.0)
-    eventmachine (1.0.7)
-    execjs (2.5.2)
-    faye-websocket (0.9.2)
+    eventmachine (1.0.9.1)
+    execjs (2.6.0)
+    faye-websocket (0.10.2)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
-    globalid (0.3.5)
+    globalid (0.3.6)
       activesupport (>= 4.1.0)
     hiredis (0.5.2)
-    hitimes (1.2.2)
     i18n (0.7.0)
-    jbuilder (2.3.1)
-      activesupport (>= 3.0.0, < 5)
+    jbuilder (2.4.0)
+      activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
-    jquery-rails (4.0.4)
+    jquery-rails (4.1.0)
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
-    loofah (2.0.2)
+    loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
-    mime-types (2.6.1)
-    mini_portile (0.6.2)
-    minitest (5.7.0)
+    mime-types (2.99)
+    mini_portile2 (2.0.0)
+    minitest (5.8.3)
     multi_json (1.11.2)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
-    puma (2.11.3)
-      rack (>= 1.1, < 2.0)
-    rack (1.6.4)
+    nokogiri (1.6.7.1)
+      mini_portile2 (~> 2.0.0.rc2)
+    puma (2.15.3)
+    rack (2.0.0.alpha)
+      json
     rack-test (0.6.3)
       rack (>= 1.0)
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
-    rails-dom-testing (1.0.6)
+    rails-dom-testing (1.0.7)
       activesupport (>= 4.2.0.beta, < 5.0)
       nokogiri (~> 1.6.0)
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.2)
       loofah (~> 2.0)
-    rake (10.4.2)
-    redis (3.2.1)
-    sass (3.4.16)
-    sass-rails (5.0.3)
+    rake (10.5.0)
+    redis (3.2.2)
+    sass (3.4.21)
+    sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
       sass (~> 3.1)
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
-      tilt (~> 1.1)
-    spring (1.3.6)
-    sprockets (3.2.0)
-      rack (~> 1.0)
-    sqlite3 (1.3.10)
+      tilt (>= 1.1, < 3)
+    spring (1.6.2)
+    sprockets (3.5.2)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
+    sqlite3 (1.3.11)
     thor (0.19.1)
     thread_safe (0.3.5)
-    tilt (1.4.1)
-    timers (4.0.1)
-      hitimes
-    turbolinks (2.5.3)
-      coffee-rails
+    tilt (2.0.2)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uglifier (2.7.1)
+    uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
-    websocket-driver (0.5.4)
+    websocket-driver (0.6.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
 
@@ -197,7 +188,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  actioncable!
   arel!
   byebug
   coffee-rails!
@@ -209,9 +199,9 @@ DEPENDENCIES
   spring
   sprockets-rails!
   sqlite3
-  turbolinks
+  turbolinks!
   uglifier (>= 1.3.0)
   web-console!
 
 BUNDLED WITH
-   1.10.5
+   1.11.2

--- a/app/assets/javascripts/channels/index.coffee
+++ b/app/assets/javascripts/channels/index.coffee
@@ -1,6 +1,6 @@
-#= require cable
+#= require action_cable
 #= require_self
 #= require_tree .
 
 @App = {}
-App.cable = Cable.createConsumer 'ws://localhost:28080'
+App.cable = ActionCable.createConsumer()

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,7 @@
 <html>
 <head>
   <title>Action Cable Examples</title>
+  <%= action_cable_meta_tag %>
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track': true %>
   <%= csrf_meta_tags %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,4 +38,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Set Action Cable server url for consumer connection
+  config.action_cable.url = 'ws://localhost:28080'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,4 +74,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Set Action Cable server url for consumer connection
+  # config.action_cable.url = 'ws://cable.example.com:28080'
 end

--- a/config/redis/cable.yml
+++ b/config/redis/cable.yml
@@ -1,14 +1,8 @@
-# production: &production
-#   :url: redis://localhost:6379
-#   :host: localhost
-#   :port: 6379
-#   :timeout: 1
+# production:
+#   url: redis://redis.example.com:6379
 
 local: &local
-  :url: redis://localhost:6379
-  :host: localhost
-  :port: 6379
-  :timeout: 1
-  :inline: true
+  url: redis://localhost:6379
+
 development: *local
 test: *local


### PR DESCRIPTION
* Update Gemfile/Gemfile.lock for Rails 5
* Update naming of Cable to ActionCable
* Remove unnecessary Redis configuration values
* Make use of Action Cable meta tag for configuration