### PR TITLE
Use turbolinks:load instead of page:change

### DIFF
--- a/app/assets/javascripts/channels/comments.coffee
+++ b/app/assets/javascripts/channels/comments.coffee
@@ -23,4 +23,4 @@ App.comments = App.cable.subscriptions.create "CommentsChannel",
   installPageChangeCallback: ->
     unless @installedPageChangeCallback
       @installedPageChangeCallback = true
-      $(document).on 'page:change', -> App.comments.followCurrentMessage()
+      $(document).on 'turbolinks:load', -> App.comments.followCurrentMessage()


### PR DESCRIPTION
Fix: https://github.com/rails/actioncable-examples/issues/31

I found that `page:change` is for Turbolinks Classic and no longer works for Turbolinks5.

See:
https://github.com/turbolinks/turbolinks-classic
https://github.com/turbolinks/turbolinks

