### PR TITLE
specify rails version in migrations

### DIFF
--- a/db/migrate/20150711093646_create_users.rb
+++ b/db/migrate/20150711093646_create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < ActiveRecord::Migration[5.1]
   def change
     create_table :users do |t|
       t.string :name

--- a/db/migrate/20150711101414_create_messages.rb
+++ b/db/migrate/20150711101414_create_messages.rb
@@ -1,7 +1,7 @@
-class CreateMessages < ActiveRecord::Migration
+class CreateMessages < ActiveRecord::Migration[5.1]
   def change
     create_table :messages do |t|
-      t.references :user, index: true, foreign_key: true
+      t.references :user, foreign_key: true
 
       t.string :title
       t.text :content

--- a/db/migrate/20150711103112_create_comments.rb
+++ b/db/migrate/20150711103112_create_comments.rb
@@ -1,8 +1,8 @@
-class CreateComments < ActiveRecord::Migration
+class CreateComments < ActiveRecord::Migration[5.1]
   def change
     create_table :comments do |t|
-      t.references :message, index: true, foreign_key: true
-      t.references :user, index: true, foreign_key: true
+      t.references :message, foreign_key: true
+      t.references :user, foreign_key: true
 
       t.text :content
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -14,9 +13,9 @@
 ActiveRecord::Schema.define(version: 20150711103112) do
 
   create_table "comments", force: :cascade do |t|
-    t.integer  "message_id"
-    t.integer  "user_id"
-    t.text     "content"
+    t.integer "message_id"
+    t.integer "user_id"
+    t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["message_id"], name: "index_comments_on_message_id"
@@ -24,16 +23,16 @@ ActiveRecord::Schema.define(version: 20150711103112) do
   end
 
   create_table "messages", force: :cascade do |t|
-    t.integer  "user_id"
-    t.string   "title"
-    t.text     "content"
+    t.integer "user_id"
+    t.string "title"
+    t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_messages_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "name"
+    t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
I forgot about this when I updated to Rails 5.1 https://github.com/rails/actioncable-examples/pull/39 🙈 

Thanks to @woto for pointing this out here https://github.com/rails/actioncable-examples/issues/41 